### PR TITLE
Revamp styles for black and white VC theme

### DIFF
--- a/index.html
+++ b/index.html
@@ -4,9 +4,11 @@
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Adelante Ventures LLC</title>
-    <!-- Google Fonts -->
+    <!-- Google Fonts: DM Serif Text -->
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
     <link
-      href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600&family=Roboto:wght@300;400;500&display=swap"
+      href="https://fonts.googleapis.com/css2?family=DM+Serif+Text:ital@0;1&display=swap"
       rel="stylesheet"
     />
     <!-- Bootstrap 5 CSS -->

--- a/public/index.html
+++ b/public/index.html
@@ -4,8 +4,10 @@
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Adelante Ventures LLC</title>
-    <!-- Google Fonts -->
-    <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600&family=Roboto:wght@300;400;500&display=swap" rel="stylesheet">
+    <!-- Google Fonts: DM Serif Text -->
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link href="https://fonts.googleapis.com/css2?family=DM+Serif+Text:ital@0;1&display=swap" rel="stylesheet">
     <!-- Bootstrap 5 CSS -->
     <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css" rel="stylesheet">
     <!-- Font Awesome 6 -->

--- a/src/App.css
+++ b/src/App.css
@@ -18,10 +18,8 @@
   --spacing-5: 3rem;
 
   /* Typography */
-  --font-primary: "Inter", -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto,
-    "Helvetica Neue", Arial, sans-serif;
-  --font-secondary: "Roboto", -apple-system, BlinkMacSystemFont, "Segoe UI",
-    Roboto, "Helvetica Neue", Arial, sans-serif;
+  --font-primary: "DM Serif Text", serif;
+  --font-secondary: "DM Serif Text", serif;
 
   /* Shadows */
   --shadow-sm: 0 0.125rem 0.25rem rgba(0, 0, 0, 0.075);

--- a/src/App.css
+++ b/src/App.css
@@ -1,14 +1,14 @@
 :root {
   /* Color System */
-  --clr-primary: #0052ff;
-  --clr-primary-light: #e6eeff;
-  --clr-secondary: #6c757d;
-  --clr-light: #f8f9fa;
-  --clr-dark: #212529;
+  --clr-primary: #000000;
+  --clr-primary-light: #f5f5f5;
+  --clr-secondary: #333333;
+  --clr-light: #ffffff;
+  --clr-dark: #000000;
   --clr-white: #ffffff;
   --clr-muted: #6c757d;
-  --clr-gradient-start: #e6eeff;
-  --clr-gradient-end: #ffffff;
+  --clr-gradient-start: #ffffff;
+  --clr-gradient-end: #f5f5f5;
 
   /* Spacing */
   --spacing-1: 0.5rem;
@@ -148,7 +148,8 @@ a:hover {
   right: 0;
   left: 0;
   z-index: 1030;
-  background-color: var(--clr-white);
+  background-color: rgba(255, 255, 255, 0.8);
+  backdrop-filter: blur(10px);
   box-shadow: var(--shadow-sm);
   padding: 0.75rem 0;
 }
@@ -212,8 +213,8 @@ a:hover {
 }
 
 .btn-primary:hover {
-  background-color: #0046d9;
-  border-color: #0040cc;
+  background-color: #333333;
+  border-color: #333333;
 }
 
 .btn-outline-primary {
@@ -234,11 +235,24 @@ a:hover {
   display: flex;
   align-items: center;
   padding: var(--spacing-5) 0;
-  background: linear-gradient(
-    130deg,
-    var(--clr-gradient-start),
-    var(--clr-gradient-end)
-  );
+  color: var(--clr-white);
+  background: url('https://images.unsplash.com/photo-1683585940689-7fd8aa12d682?q=80&w=2532&auto=format&fit=crop&ixlib=rb-4.1.0&ixid=M3wxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8fA%3D%3D')
+    center/cover no-repeat fixed;
+  position: relative;
+}
+
+.home-page::before {
+  content: '';
+  position: absolute;
+  top: 0;
+  right: 0;
+  bottom: 0;
+  left: 0;
+  background: rgba(0, 0, 0, 0.5);
+}
+
+.home-page > * {
+  position: relative;
 }
 
 /* About Page */
@@ -248,7 +262,7 @@ a:hover {
   display: flex;
   align-items: center;
   background: linear-gradient(
-    130deg,
+    180deg,
     var(--clr-gradient-start),
     var(--clr-gradient-end)
   );

--- a/src/index.css
+++ b/src/index.css
@@ -1,12 +1,9 @@
 :root {
-  font-family: system-ui, Avenir, Helvetica, Arial, sans-serif;
+  font-family: 'Inter', 'Roboto', sans-serif;
   line-height: 1.5;
   font-weight: 400;
-
-  color-scheme: light dark;
-  color: rgba(255, 255, 255, 0.87);
-  background-color: #242424;
-
+  color: #000;
+  background-color: #fff;
   font-synthesis: none;
   text-rendering: optimizeLegibility;
   -webkit-font-smoothing: antialiased;
@@ -15,11 +12,11 @@
 
 a {
   font-weight: 500;
-  color: #646cff;
-  text-decoration: inherit;
+  color: #000;
+  text-decoration: none;
 }
 a:hover {
-  color: #535bf2;
+  color: #333;
 }
 
 /* Base styles */
@@ -55,27 +52,15 @@ button {
   font-size: 1em;
   font-weight: 500;
   font-family: inherit;
-  background-color: #1a1a1a;
+  background-color: #000;
   cursor: pointer;
   transition: border-color 0.25s;
 }
 button:hover {
-  border-color: #646cff;
+  border-color: #333;
 }
 button:focus,
 button:focus-visible {
   outline: 4px auto -webkit-focus-ring-color;
 }
 
-@media (prefers-color-scheme: light) {
-  :root {
-    color: #213547;
-    background-color: #ffffff;
-  }
-  a:hover {
-    color: #747bff;
-  }
-  button {
-    background-color: #f9f9f9;
-  }
-}

--- a/src/index.css
+++ b/src/index.css
@@ -1,5 +1,5 @@
 :root {
-  font-family: 'Inter', 'Roboto', sans-serif;
+  font-family: 'DM Serif Text', serif;
   line-height: 1.5;
   font-weight: 400;
   color: #000;
@@ -29,7 +29,7 @@ a:hover {
 body {
   margin: 0;
   padding: 0;
-  font-family: 'Inter', 'Roboto', sans-serif;
+  font-family: 'DM Serif Text', serif;
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
 }


### PR DESCRIPTION
## Summary
- switch to a monochrome palette
- add glassy navbar
- add Unsplash hero background with overlay
- simplify base styles

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68781b22b80c8333908748fd56e1afcc